### PR TITLE
Add JUnit tests for LogEntry parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,26 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/src/main/java/LogEntry.java
+++ b/src/main/java/LogEntry.java
@@ -1,0 +1,71 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a parsed line from an access log.
+ */
+public class LogEntry {
+    private final String ipAddress;
+    private final String request;
+    private final int status;
+    private final long bytes;
+    private final String userAgent;
+
+    private LogEntry(String ipAddress, String request, int status, long bytes, String userAgent) {
+        this.ipAddress = ipAddress;
+        this.request = request;
+        this.status = status;
+        this.bytes = bytes;
+        this.userAgent = userAgent;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public String getRequest() {
+        return request;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    private static final Pattern LOG_PATTERN = Pattern.compile(
+            "^(\\S+) \\S+ \\S+ \\[(.+?)\\] \"(.+?)\" (\\d{3}) (\\d+|-) \"(.*?)\" \"(.*?)\"$");
+
+    /**
+     * Parses a single line of a web server access log in the combined format.
+     *
+     * @param line log line
+     * @return parsed {@link LogEntry}
+     * @throws IllegalArgumentException if the line is malformed or exceeds 1024 characters
+     */
+    public static LogEntry parse(String line) {
+        if (line == null) {
+            throw new IllegalArgumentException("Line is null");
+        }
+        if (line.length() > 1024) {
+            throw new IllegalArgumentException("Line is longer than 1024 characters");
+        }
+        Matcher matcher = LOG_PATTERN.matcher(line);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Malformed log line");
+        }
+        String ip = matcher.group(1);
+        String request = matcher.group(3);
+        int status = Integer.parseInt(matcher.group(4));
+        String bytesStr = matcher.group(5);
+        long bytes = "-".equals(bytesStr) ? 0 : Long.parseLong(bytesStr);
+        String userAgent = matcher.group(7);
+        return new LogEntry(ip, request, status, bytes, userAgent);
+    }
+}

--- a/src/test/java/LogEntryParseTest.java
+++ b/src/test/java/LogEntryParseTest.java
@@ -1,0 +1,29 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogEntryParseTest {
+
+    private static final String VALID_LINE = "127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326 \"-\" \"Mozilla/4.08 [en] (Win98; I ;Nav)\"";
+
+    @Test
+    void parseValidLine() {
+        LogEntry entry = LogEntry.parse(VALID_LINE);
+        assertEquals("127.0.0.1", entry.getIpAddress());
+        assertEquals("GET /apache_pb.gif HTTP/1.0", entry.getRequest());
+        assertEquals(200, entry.getStatus());
+        assertEquals(2326, entry.getBytes());
+        assertEquals("Mozilla/4.08 [en] (Win98; I ;Nav)", entry.getUserAgent());
+    }
+
+    @Test
+    void parseMalformedLine() {
+        String malformed = "bad line";
+        assertThrows(IllegalArgumentException.class, () -> LogEntry.parse(malformed));
+    }
+
+    @Test
+    void parseTooLongLine() {
+        String longLine = VALID_LINE + "a".repeat(1024 - VALID_LINE.length() + 1);
+        assertThrows(IllegalArgumentException.class, () -> LogEntry.parse(longLine));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit Jupiter dependency and Surefire plugin
- implement LogEntry parser with validation
- introduce tests for valid and invalid log lines

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a31b104970832cb12a44b33ff60c28